### PR TITLE
Update tutorial readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In this tutorial, you train a classifier that can interpret a weather-related qu
 ## Before you begin
 Ensure that you have the prerequisites before you start:
 
-* You need a Bluemix account for this tutorial. If you don't have one, [sign up][sign_up]. For more information about the process, see [Developing Watson applications with Bluemix][dev_wdc_apps].
+* You need a Bluemix account for this tutorial. If you don't have one, <a target="_blank" href="https://apps.admin.ibmcloud.com/manage/trial/bluemix.html?cm_mmc=WatsonDeveloperCloud-_-LandingSiteGetStarted-_-x-_-CreateAnAccountOnBluemixCLI">sign up</a>. For more information about the process, see <a target="_blank" href="http://http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-bluemix.shtml">Developing Watson applications with Bluemix</a>.
 * The tutorial uses the Cloud-foundry CLI</a> tool to communicate with Bluemix. <a target="_blank" href="https://github.com/cloudfoundry/cli/releases">Download</a> and install the Cloud-foundry tool if you haven't already.
 * The tutorial uses the Node.js and the npm command-line tools: 
     * To verify that Node.js is installed, run the following command:
@@ -124,10 +124,10 @@ To speed up this step, the `train.json` file is included as training data. The f
 
 	```JSON
 	{
-		classifiers: [ 
+		"classifiers": [ 
 			{
-				classifier_id: "10D41B-nlc-1",
-				url: "https://gateway.watsonplatform.net/natural-language-classifier-experimental/api/v1/classifiers/10D41B-nlc-1"
+				"classifier_id": "10D41B-nlc-1",
+				"url": "https://gateway.watsonplatform.net/natural-language-classifier-experimental/api/v1/classifiers/10D41B-nlc-1"
 			} 
 		]
 	}
@@ -191,10 +191,10 @@ You successfully completed the process of training and querying a classifier in 
 
 So that you can create classifiers for your own use and with your own ground truth, you might want to delete this classifier from the tutorial. To delete the classifier that you created in this tutorial, call the `DELETE v1/classifiers/{classifier_id}` method:
 
-* Run the following command to delete the classifier. Replace `<classifier_id>` with the ID of your classifier:
+* Run the `delete` command to delete the classifier. Include the `classifier_id` for the classifier you want to delete.  For example:
 
 	```node
-	$ node natural-language-classifier-cli.js delete -c <classifier_id>
+	$ node natural-language-classifier-cli.js delete -c 10D41B-nlc-1
 	```
 
 	If the classifier is deleted, the response is an HTTP 200 code.
@@ -221,8 +221,6 @@ This library is licensed under Apache 2.0. Full license text is available in
 See [CONTRIBUTING](CONTRIBUTING.md).
 
 
-[sign_up]: https://apps.admin.ibmcloud.com/manage/trial/bluemix.html?cm_mmc=WatsonDeveloperCloud-_-LandingSiteGetStarted-_-x-_-CreateAnAccountOnBluemixCLI
-[dev_wdc_apps]: http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-bluemix.shtml
 [overview]: http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/nl-classifier/
 [reference]: http://watson.stage1.mybluemix.net/apis/#!/natural-language-classifier
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In this tutorial, you train a classifier that can interpret a weather-related qu
 ## Before you begin
 Ensure that you have the prerequisites before you start:
 
-* You need a Bluemix account for this tutorial. If you don't have one, <a target="_blank" href="https://apps.admin.ibmcloud.com/manage/trial/bluemix.html?cm_mmc=WatsonDeveloperCloud-_-LandingSiteGetStarted-_-x-_-CreateAnAccountOnBluemixCLI">sign up</a>. For more information about the process, see <a target="_blank" href="http://http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-bluemix.shtml">Developing Watson applications with Bluemix</a>.
+* You need a Bluemix account for this tutorial. If you don't have one, <a target="_blank" href="https://apps.admin.ibmcloud.com/manage/trial/bluemix.html?cm_mmc=WatsonDeveloperCloud-_-LandingSiteGetStarted-_-x-_-CreateAnAccountOnBluemixCLI">sign up</a>. For more information about the process, see <a target="_blank" href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-bluemix.shtml">Developing Watson applications with Bluemix</a>.
 * The tutorial uses the Cloud-foundry CLI</a> tool to communicate with Bluemix. <a target="_blank" href="https://github.com/cloudfoundry/cli/releases">Download</a> and install the Cloud-foundry tool if you haven't already.
 * The tutorial uses the Node.js and the npm command-line tools: 
     * To verify that Node.js is installed, run the following command:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In this tutorial, you train a classifier that can interpret a weather-related qu
 Ensure that you have the prerequisites before you start:
 
 * You need a Bluemix account for this tutorial. If you don't have one, <a target="_blank" href="https://apps.admin.ibmcloud.com/manage/trial/bluemix.html?cm_mmc=WatsonDeveloperCloud-_-LandingSiteGetStarted-_-x-_-CreateAnAccountOnBluemixCLI">sign up</a>. For more information about the process, see <a target="_blank" href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-bluemix.shtml">Developing Watson applications with Bluemix</a>.
-* The tutorial uses the Cloud-foundry CLI</a> tool to communicate with Bluemix. <a target="_blank" href="https://github.com/cloudfoundry/cli/releases">Download</a> and install the Cloud-foundry tool if you haven't already.
+* The tutorial uses the Cloud-foundry CLI tool to communicate with Bluemix. <a target="_blank" href="https://github.com/cloudfoundry/cli/releases">Download</a> and install the Cloud-foundry tool if you haven't already.
 * The tutorial uses the Node.js and the npm command-line tools: 
     * To verify that Node.js is installed, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
-# Natural Language Classifier CLI tool 
-Command line interface (CLI) for the IBM Watson&trade; Natural Language Classifier service. 
-
-## Tutorial
-This tutorial guides you through the process of creating and setting up a classifier by using the Node.js wrapper command line interface. This tutorial teaches you how to create, train, and use a classifier.
+# Natural Language Classifier tutorial 
+This tutorial guides you through the process of creating and setting up a classifier by using a Node.js wrapper command-line interface for the IBM Watson&trade; Natural Language Classifier service. This tutorial teaches you how to create, train, and use a classifier.
 
 In this tutorial, you train a classifier that can interpret a weather-related question and return either "temperature" or "condition." For example, for the question, "Is it windy," the system returns "conditions".  For the question, "Is it hot outside," the service returns "temperature".
 
 ***
 ## Before you begin
-Ensure that you have the necessary prerequisites before you start:
+Ensure that you have the prerequisites before you start:
 
-* You need a Bluemix account for this tutorial. If you don't have one, [sign up][sign_up]. For more details about the process, see [Developing Watson applications with Bluemix][dev_wdc_apps].
-* The tutorial is designed to use the [Cloud-foundry CLI][cloud_foundry] tool. Download and install the tool if you haven't already.
-* The tutorial uses [Node.js](http://nodejs.org/) and [npm](https://www.npmjs.com/). Download and install those tools if you haven't already.
+* You need a Bluemix account for this tutorial. If you don't have one, [sign up][sign_up]. For more information about the process, see [Developing Watson applications with Bluemix][dev_wdc_apps].
+* The tutorial uses the Cloud-foundry CLI</a> tool to communicate with Bluemix. <a target="_blank" href="https://github.com/cloudfoundry/cli/releases">Download</a> and install the Cloud-foundry tool if you haven't already.
+* The tutorial uses the Node.js and the npm command-line tools: 
+    * To verify that Node.js is installed, run the following command:
+
+		```sh
+		$ node -v
+		```
+
+		<a target="_blank" href="https://docs.npmjs.com/getting-started/installing-node">Download</a> and install Node.js if it is not installed. 
+
+    * The npm tool is bundled with node. If you have a recent version of Node.js installed, then npm is installed. To verify, run the following command:
+		
+		```sh
+		$ npm -v
+		```
+
 
 ## Stages
-To get started with the Natural Language Classifier CLI and complete the tutorial, complete each of the following stages in order:
+To get started with the Natural Language Classifier service and complete the tutorial, complete each of the following stages in order:
 
 1. [Obtain your Bluemix credentials](#stage-1-obtain-your-bluemix-credentials) 
 2. [Configure the code to connect to your service](#stage-2-configure-the-code-to-connect-to-your-service)
@@ -27,27 +38,31 @@ To get started with the Natural Language Classifier CLI and complete the tutoria
 
 ***
 
-## Stage 1: Obtain your Bluemix credentials
-Before you can work with a service in Bluemix, you must obtain your Bluemix credentials. If you already have your credentials for the Natural Language Classifier service, you can skip this step.
+## Stage 1: Obtain your service credentials
+Before you can work with a service in Bluemix, you must obtain your service credentials. If you already have your credentials for the Natural Language Classifier service, you can skip this step.
 
-1. Log into Bluemix:
-	1. Click the **LOG IN** button in the upper right-hand corner of the page at console.ng.bluemix.net.
+The following steps obtain the service credentials by creating a web application in Node.js for the Natural Language Classifier service. You are completing these steps only to obtain your service credentials for Bluemix.
+
+To view a video, see <a target = "_blank" href="https://www.youtube.com/watch?v=X95CMuQys-g">Getting Service Credentials</a>.
+
+1. Log in to Bluemix:
+	1. Click **LOG IN** in the upper right corner of the page at <a target="_blank" href="https://console.ng.bluemix.net">console.ng.bluemix.net</a>.
 	2. Enter your Bluemix ID and password on the authentication page.
 2. Create an app:
 	1. Click **Create an app**.
 	2. Select **Web**.
 	3. Select the starter **SDK for Node.js**, and click **Continue**.
 	4. Type a unique name for your app, for example, `TutorialClassifier-<username>`, and click **Finish**.
-	5. Select the button for **CF Command Line Interface**.
+	5. Select **CF Command Line Interface**.
 	6. Click **View App Overview**.
 3. Add the Natural Language Classifier service to your app:
 	1. Click **Add a service or API** on the app **Overview** page.
-	2. In the Bluemix **Catalog**, select the Natural Language Classifier service. The service is located in the Bluemix Labs section of IBM Bluemix. Click **Bluemix Labs Catalog** at the bottom of the page.
+	2. In the Bluemix **Catalog**, select the Natural Language Classifier service. The service is in the Bluemix Labs section of IBM Bluemix. Click **Bluemix Labs Catalog** at the bottom of the page.
 	3. In the **Service name** field, type a unique name for the service instance, for example `Classifier-tutorial-<username>`, and click **Create**.
 	4. The **Restage Application** window is displayed. Click **Restage** to restage your app.
 3. Copy your credentials:
 	1. In the tile for the Natural Language Classifier service, select the **Show Credentials** link to view your Bluemix credentials.
-	2. Copy `username` and `password` from the credentials.
+	2. Copy `username` and `password` from these service credentials.
 
 
 ***
@@ -56,18 +71,18 @@ Before you can work with a service in Bluemix, you must obtain your Bluemix cred
 Download the tutorial code and configure it. Install the node.js client.
 
 1. Set up your environment:
-	1. Download the [.zip](https://github.com/watson-developer-cloud/natural-language-classifier-nodejs-cli/archive/master.zip) file that contains the source code from this project. If you are familiar with Git, fork the repository into your Git namespace or clone it to your local system.
+	1. Download the [.zip](https://github.com/watson-developer-cloud/natural-language-classifier-nodejs-cli/archive/master.zip) file that contains the source code from this project.
 	2. Extract the package to a new directory.
 
 2. Change to the new directory that contains this tutorial, for example:
 
 	```sh
-	$ cd natural-language-classifier-nodejs-cli
+	$ cd natural-language-classifier-nodejs-cli-master
 	```
 
-3. Modify the tutorial to use your credentials:
+3. Modify the tutorial to use your service credentials:
 	1. Open the `creds.js` file with a text editor.
-	2. Paste in your username and password credentials for the service from Stage 1. For example:
+	2. Paste your username and password from the service credentials from Stage 1. For example:
 
 		```js
 		var natural_language_classifier = watson.natural_language_classifier({
@@ -79,7 +94,7 @@ Download the tutorial code and configure it. Install the node.js client.
 
 	3. Save the `creds.js` file.
 
-4. Install the Natural Language Classifier CLI package:
+4. Install the Natural Language Classifier CLI package by running the following command. The package includes all the commands that you need to work with a classifier from the command line:
 
 	```node
 	$ npm install
@@ -88,12 +103,11 @@ Download the tutorial code and configure it. Install the node.js client.
 ***
 
 ## Stage 3: Create and train a classifier
-The classifier learns from examples before it can return information for texts that it hasn't seen before. The example data is referred to as "ground truth". The ground truth is a set of text strings and one or more class identifiers. You upload the ground truth to use for training when you create a classifier.
+The classifier learns from examples before it can return information for texts that it hasn't seen before. The example data is referred to as "training data." Training data is a set of text and one or more class identifiers. You upload the training data when you create a classifier.
 
-To speed up this step, the `train.json` file is included the ground truth data. The file is already formatted to work with the Natural Language Classification service.
+To speed up this step, the `train.json` file is included as training data. The file is already formatted to work with the Natural Language Classifier service.
 
-
-1. Set the target endpoint and log in to Bluemix by using the Cloud-foundry CLI:
+1. Set the target endpoint and log in to Bluemix by using the Cloud-foundry CLI. **Important**: The login uses your Bluemix account email and password:
 
 	```sh
 	$ cf api https://api.ng.bluemix.net
@@ -106,19 +120,26 @@ To speed up this step, the `train.json` file is included the ground truth data. 
 	$ node natural-language-classifier-cli.js create -f resources/weather_data_train.json
 	```
 
-	The response includes the classifier ID and status. You need the ID for the following stages. To retrieve the ID and status of all your classifiers, you can use the `GET /v1/classifiers` method. To use the wrapper to list the classifiers, run the following command:
+	The response includes the classifier ID and status. You need the value of the `classifier_id` for the following stages. For example: 
 
+	```JSON
+	{
+		classifiers: [ 
+			{
+				classifier_id: "10D41B-nlc-1",
+				url: "https://gateway.watsonplatform.net/natural-language-classifier-experimental/api/v1/classifiers/10D41B-nlc-1"
+			} 
+		]
+	}
 	```
-	$ node natural-language-classifier-cli.js list
-	```
+
+	**Tip**: To retrieve the IDs for all your classifiers, run `$ node natural-language-classifier-cli.js list`. For a list of available commands, run `$ node natural-language-classifier-cli.js --help`.
 
 ***
 
 ## Stage 4: Monitor the training status of the classifier
 
 The new classifier must finish training and return the status of `Available` before you can work with it.
-
-**Tip:** For a list of available commands, run `$ node natural-language-classifier-cli.js --help`.
 
 1. Run the following command to retrieve the status of classifier that you created in the previous stage. Replace `<classifier_id>` with the ID of your classifier:
 
@@ -140,7 +161,7 @@ Now that the classifier is trained, you can query it.
 	$ node natural-language-classifier-cli.js classify -c <classifier_id> -t "How hot will it be today?"
 	```
 
-	The API returns a reponse that includes the name of class for which the classifier has the highest confidence. Other class-confidence pairs are listed in descending order of confidence:
+	The API returns a response that includes the name of class for which the classifier has the highest confidence. Other class-confidence pairs are listed in descending order of confidence:
 
 	```JSON
 	{
@@ -188,7 +209,7 @@ So that you can create classifiers for your own use and with your own ground tru
 
 ***
 
-## Open Source @ IBM
+## Open source @ IBM
 [Find more open source projects on the IBM Github Page.](http://ibm.github.io/)
 
 ## License
@@ -202,7 +223,6 @@ See [CONTRIBUTING](CONTRIBUTING.md).
 
 [sign_up]: https://apps.admin.ibmcloud.com/manage/trial/bluemix.html?cm_mmc=WatsonDeveloperCloud-_-LandingSiteGetStarted-_-x-_-CreateAnAccountOnBluemixCLI
 [dev_wdc_apps]: http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-bluemix.shtml
-[cloud_foundry]: https://github.com/cloudfoundry/cli/releases
 [overview]: http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/nl-classifier/
 [reference]: http://watson.stage1.mybluemix.net/apis/#!/natural-language-classifier
 


### PR DESCRIPTION
Some testing has revealed confusion with the Tutorial readme. For example,

* Reference to command line in title
* Difficulty finding node/npm installation info
* Complementary links not opening in separate tabs
* Confusion about bluemix email id vs session credentials
* Example directory name that doesn't match .zip file

These updates attempt to address these issues.